### PR TITLE
Update SpiffWorkflow import

### DIFF
--- a/src/flask_bpmn/api/api_error.py
+++ b/src/flask_bpmn/api/api_error.py
@@ -9,7 +9,7 @@ from flask import Blueprint
 from flask import current_app
 from flask import g
 from marshmallow import Schema
-from SpiffWorkflow import WorkflowException  # type: ignore
+from SpiffWorkflow.exceptions import WorkflowException  # type: ignore
 from SpiffWorkflow.bpmn.exceptions import WorkflowTaskExecException  # type: ignore
 from SpiffWorkflow.specs.base import TaskSpec  # type: ignore
 from SpiffWorkflow.task import Task  # type: ignore


### PR DESCRIPTION
In https://github.com/sartography/SpiffWorkflow/pull/245 I removed the contents of the root `__init__.py` file, which will require this import change.